### PR TITLE
Update depreciated jack_client_new calls with jack_client_open calls.

### DIFF
--- a/examples/circlescope.c
+++ b/examples/circlescope.c
@@ -104,7 +104,7 @@ void jack_shutdown (void *arg)
 int main (int argc, char *argv[])
 {
 	jack_client_t *client;
-	const char jack_client_name[] = "circlescope";
+	static const char jack_client_name[] = "circlescope";
 	jack_status_t jack_status;	
 
 	if ((client = jack_client_open(jack_client_name, JackNullOption, &jack_status)) == 0) {

--- a/examples/scope.c
+++ b/examples/scope.c
@@ -104,7 +104,7 @@ void jack_shutdown (void *arg)
 int main (int argc, char *argv[])
 {
 	jack_client_t *client;
-	const char jack_client_name[] = "scope";
+	static const char jack_client_name[] = "scope";
 	jack_status_t jack_status;
 
 	if ((client = jack_client_open(jack_client_name, JackNullOption, &jack_status)) == 0) {

--- a/libol/libol.c
+++ b/libol/libol.c
@@ -229,7 +229,7 @@ static int process (nframes_t nframes, void *arg)
 int olInit(int buffer_count, int max_points)
 {
 	int i;
-	const char jack_client_name[] = "libol";
+	static const char jack_client_name[] = "libol";
 	jack_status_t jack_status;
 	
 	if (buffer_count < 2)

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -226,7 +226,7 @@ int main (int argc, char *argv[])
 {
 	int retval;
 	jack_client_t *client;
-	const char jack_client_name[] = "output";
+	static const char jack_client_name[] = "output";
 	jack_status_t jack_status;	
 
 	QApplication app(argc, argv);

--- a/tools/playilda.c
+++ b/tools/playilda.c
@@ -459,7 +459,7 @@ int main (int argc, char *argv[])
 	char **argvp = &argv[1];
 	char *fname;
 	jack_client_t *client;
-	const char jack_client_name[] = "playilda";
+	static const char jack_client_name[] = "playilda";
 	jack_status_t jack_status;	
 	struct stat st1, st2;
 

--- a/tools/simulator.c
+++ b/tools/simulator.c
@@ -231,7 +231,7 @@ void init_gl(int width, int height)
 
 int main (int argc, char *argv[])
 {
-	const char jack_client_name[] = "simulator";
+	static const char jack_client_name[] = "simulator";
 	jack_status_t jack_status;
 	
 	if ((client = jack_client_open(jack_client_name, JackNullOption, &jack_status)) == 0) {


### PR DESCRIPTION
jack_client_new is depreciated and generates warnings.  
