### PR TITLE
olGetCharWidth() now takes a 'height' scalar arg

### DIFF
--- a/include/text.h
+++ b/include/text.h
@@ -41,7 +41,7 @@ typedef struct {
 } Font;
 
 Font *olGetDefaultFont(void);
-float olGetCharWidth(Font *fnt, char c);
+float olGetCharWidth(Font *font, float height, char c);
 float olGetStringWidth(Font *fnt, float height, const char *s);
 float olGetCharOverlap(Font *font, float height);
 float olDrawChar(Font *fnt, float x, float y, float height, uint32_t color, char c);

--- a/libol/text.c
+++ b/libol/text.c
@@ -28,11 +28,12 @@ Font *olGetDefaultFont(void)
 	return &default_font;
 }
 
-float olGetCharWidth(Font *font, char c)
+float olGetCharWidth(Font *font, float height, char c)
 {
 	if (!font)
 		return 0;
-	return font->chars[(uint8_t)c].width / font->height;
+	float ratio = height / font->height;
+	return font->chars[(uint8_t)c].width * ratio;
 }
 
 float olGetCharOverlap(Font *font, float height)

--- a/python/pylase.pyx
+++ b/python/pylase.pyx
@@ -427,7 +427,7 @@ cdef extern from "text.h":
 	ctypedef struct _Font "Font"
 
 	_Font *olGetDefaultFont()
-	float olGetCharWidth(_Font *fnt, char c)
+	float olGetCharWidth(_Font *fnt, float height, char c)
 	float olGetStringWidth(_Font *fnt, float height, char *s)
 	float olGetCharOverlap(_Font *font, float height)
 	float olDrawChar(_Font *fnt, float x, float y, float height, uint32_t color, char c)
@@ -441,9 +441,9 @@ cpdef getDefaultFont():
 	f.font = olGetDefaultFont()
 	return f
 
-cpdef float getCharWidth(object font, char c):
+cpdef float getCharWidth(object font, float height, char c):
 	cdef Font fnt = font
-	return olGetCharWidth(fnt.font, c)
+	return olGetCharWidth(fnt.font, height, c)
 cpdef float getStringWidth(object font, float height, char *s):
 	cdef Font fnt = font
 	return olGetStringWidth(fnt.font, height, s)


### PR DESCRIPTION
... same as the rest of font routines do.

Signed-off-by: Kamal Mostafa kamal@whence.com
